### PR TITLE
Update default option in readme to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ grunt.loadNpmTasks('grunt-cssjanus');
 
 #### options.swapLtrRtlInUrl
 Type: `Boolean`
-Default value: `false`
+Default value: `true`
 
 Whether to replace 'ltr' with 'rtl' and vice versa in urls.
 


### PR DESCRIPTION
According to https://github.com/yoavf/grunt-cssjanus/blob/master/tasks/cssjanus.js#L15 the default value for swapLtrRtlInUrl is actually true
